### PR TITLE
umad2sim: do not use umad.h deprecated function

### DIFF
--- a/umad2sim/umad2sim.c
+++ b/umad2sim/umad2sim.c
@@ -442,7 +442,7 @@ static ssize_t umad2sim_read(struct umad2sim_dev *dev, void *buf, size_t count)
 	umad->status = ntohl(req.status);
 	umad->timeout_ms = 0;
 	umad->retries = 0;
-	umad->length = umad_size() + ntohll(req.length);
+	umad->length = umad_size() + be64toh(req.length);
 
 	umad->addr.qpn = req.sqp;
 	umad->addr.qkey = 0;	// agent->qkey;
@@ -506,7 +506,7 @@ static ssize_t umad2sim_write(struct umad2sim_dev *dev,
 		cnt = sizeof(req.mad);
 	memcpy(req.mad, umad_get_mad(umad), cnt);
 
-	req.length = htonll(cnt);
+	req.length = htobe64(cnt);
 
 	if (!mad_get_field(req.mad, 0, IB_MAD_RESPONSE_F)) {
 		uint64_t trid = mad_get_field64(req.mad, 0, IB_MAD_TRID_F);


### PR DESCRIPTION
ntohll and htonll are deprecated in libibumad. Use the glibc functions instead

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>