### PR TITLE
Exclude tests folder from install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-subdirs:= ibsim umad2sim tests
+subdirs:= ibsim umad2sim
+subdirs_with_tests:=$(subdirs) tests
 
-all clean dep install:
+all clean dep:
+	$(foreach dir, $(subdirs_with_tests), make -C $(dir) $@ && ) echo "Done."
+
+install:
 	$(foreach dir, $(subdirs), make -C $(dir) $@ && ) echo "Done."
 
 dist:


### PR DESCRIPTION
Fix RPM build errors when installing tests folder
see https://github.com/linux-rdma/ibsim/issues/8

make -C ibsim install &&   make -C umad2sim install &&   make -C tests install &&  echo "Done."
make[1]: Entering directory `/root/rpmbuild/BUILD/ibsim-0.8/ibsim'
install -d /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/bin
install -d /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/lib64/umad2sim
install ibsim /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/bin
make[1]: Leaving directory `/root/rpmbuild/BUILD/ibsim-0.8/ibsim'
make[1]: Entering directory `/root/rpmbuild/BUILD/ibsim-0.8/umad2sim'
install -d /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/bin
install -d /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/lib64/umad2sim
install libumad2sim.so /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/lib64/umad2sim
make[1]: Leaving directory `/root/rpmbuild/BUILD/ibsim-0.8/umad2sim'
make[1]: Entering directory `/root/rpmbuild/BUILD/ibsim-0.8/tests'
install -d /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/bin
install -d /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/lib64/umad2sim
install subnet_discover /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/bin  install query_many /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/bin  install mcast_storm /root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/bin
install: omitting directory '/root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/bin'
install: cannot stat 'install': No such file or directory
install: omitting directory '/root/rpmbuild/BUILDROOT/ibsim-0.8-1.el7.x86_64/usr/bin'
install: cannot stat 'install': No such file or directory
make[1]: *** [install] Error 1
make[1]: Leaving directory `/root/rpmbuild/BUILD/ibsim-0.8/tests'
make: *** [install] Error 2
error: Bad exit status from /var/tmp/rpm-tmp.2AgKKI (%install)

RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.2AgKKI (%install)