### PR TITLE
Fix two compilation issues for Fedora Rawhide

### DIFF
--- a/ibsim/sim_net.c
+++ b/ibsim/sim_net.c
@@ -71,8 +71,6 @@ static int inclines[MAX_INCLUDE];
 static char *incfiles[MAX_INCLUDE];
 static int inclevel;
 
-int simverb;
-
 Port *default_port;
 
 static const uint8_t smaport[] = {

--- a/umad2sim/umad2sim.c
+++ b/umad2sim/umad2sim.c
@@ -109,7 +109,7 @@ static int (*real_scandir) (const char *dir, struct dirent *** namelist,
 
 static char sysfs_infiniband_dir[] = SYS_INFINIBAND;
 static char sysfs_infiniband_mad_dir[] = IB_UMAD_ABI_DIR;
-static char umad_dev_dir[] = UMAD_DEV_DIR;
+static char umad_dev_dir[] = "/dev/infiniband";
 
 static char umad2sim_sysfs_prefix[32];
 


### PR DESCRIPTION
Fix two compilation issues for Fedora 32, which has gcc-10.0.1-0.7.fc32.x86_64 and rdma-core-28.0-2.fc32.x86_64 . gcc-10 emits an duplicate definition issue. The umad.h for rdma-core-28 no longer provides C Macro 'UMAD_DEV_DIR'.