### PR TITLE
ibsim-run: a wrapper to run programs under ibsim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.build_profile
 ibsim/ibsim
+ibsim/ibsim-run
 tests/mcast_storm
 tests/query_many
 tests/subnet_discover

--- a/defs.mk
+++ b/defs.mk
@@ -13,6 +13,8 @@ libpath:= $(strip $(if $(libpath),$(libpath),\
 		$(prefix)/lib64,$(prefix)/lib)))
 binpath:= $(if $(binpath),$(binpath),$(prefix)/bin)
 
+libdir:=$(libpath)/umad2sim
+
 #IB_DEV_DIR:=$(HOME)/src/m
 ifdef IB_DEV_DIR
  INCS:= $(foreach l, mad umad, -I$(IB_DEV_DIR)/libib$(l)/include) \
@@ -40,7 +42,7 @@ all:
 %.so:
 	$(CC) -shared $(LDFLAGS) -o $@ $^ $(LIBS)
 
-$(progs):
+$(progs): %:
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 dep:
@@ -54,9 +56,9 @@ clean:
 
 install: all
 	install -d $(DESTDIR)$(binpath)
-	install -d $(DESTDIR)$(libpath)/umad2sim
+	install -d $(DESTDIR)$(libdir)
 	$(foreach p, $(progs), install $(p) $(DESTDIR)$(binpath))
-	$(foreach l, $(libs), install $(l) $(DESTDIR)$(libpath)/umad2sim)
+	$(foreach l, $(libs), install $(l) $(DESTDIR)$(libdir)
 
 $(objs): .build_profile
 .build_profile::

--- a/ibsim/Makefile
+++ b/ibsim/Makefile
@@ -1,6 +1,11 @@
-progs:=ibsim
+progs:=ibsim ibsim-run
 
 -include ../defs.mk
+
+ibsim-run: ibsim-run.in
+	sed -e 's|@sim_so@|$(libdir)/libumad2sim.so|' \
+		<$< >$@
+	chmod +x $@
 
 all: $(progs)
 ibsim: $(objs)

--- a/ibsim/ibsim-run.1
+++ b/ibsim/ibsim-run.1
@@ -1,0 +1,42 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" (C) Copyright 2020 Tzafrir Cohen <mellanox@cohens.org.il>
+.\"
+.TH ibsim\-run 1 "2020-04-05"
+
+.SH NAME
+ibsim\-run \- run programs in an ibsim-simulated envronment
+.SH SYNOPSIS
+.B ibsim\-run
+.RI [ <command> ]
+.SH DESCRIPTION
+The package ibsim simulates calls to the umad library (of the Infiniband
+user-space stack).
+
+In order to use it, you should run ibsim(1), that gets a network diagram.
+Programs that have libumad2sim.so loaded, override the calls to libumad
+with calls to the ibsim simulator.
+
+This is a script that runs commands with libumad2sim.so already
+LD_PRELOAD-ed.
+
+.SH OPTIONS
+The script will manipulate the environment and then run the rest of the
+command line in that environment. If no command was given, it will run
+bash.
+
+However the following options are supported:
+
+.TP
+.B \-h, \-\-help
+Show summary of options and exit.
+
+.SH EXAMPLES
+
+  ibsim -s path/to/net-examples/net.2sw2path4hca
+
+And in a separate shell:
+
+  ibsim-run ibdiscover
+
+.SH SEE ALSO
+.BR ibsim(1)

--- a/ibsim/ibsim-run.in
+++ b/ibsim/ibsim-run.in
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+sim_so=@sim_so@
+shell="bash"
+
+usage() {
+	me=${0##*/}
+	cat <<EOF
+$me: run commands with an ibsim-smulated stack
+
+Will run a command or start a shell with $sim_so
+LD_PRELOAD-ed.
+
+Usage:
+
+  $me <command>    # Run <command> under ibsim
+  $me              # Start a shell similarely
+  $me -h | --help  # Print this message
+
+Note: You still need to run ibsim separately.
+EOF
+}
+
+case "$1" in
+-h | --help) usage; exit 1;;
+esac
+
+if [ "$LD_PRELOAD" = '' ]; then
+	LD_PRELOAD="$sim_so"
+else
+	LD_PRELOAD="$LD_PRELOAD:sim_so"
+fi
+export LD_PRELOAD
+
+if [ "$*" = '' ]; then
+	exec $shell
+else
+	exec "$@"
+fi


### PR DESCRIPTION
The library is installed to different paths in different platforms.
This can complicate documentation and usage. So let's wrap it with
a script.

Usage:  ibsim-run command [extra parameters]

Signed-off-by: Tzafrir Cohen <mellanox@cohens.org.il>

Motivation: I want to move the path of that library in the Debian packaging, to properly support Multiarch.