### PR TITLE
run_opensm.sh: /bin/bash, as uses non-posix features

### DIFF
--- a/scripts/run_opensm.sh
+++ b/scripts/run_opensm.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$1" = "-g" ] ; then
 	debug=1


### PR DESCRIPTION
The script scripts/run_opensm.sh uses a non-standard shell feature
(not supported by e.g. dash) - time.

Mark the script as a bash script.

Signed-off-by: Tzafrir Cohen <mellanox@cohens.org.il>