### PR TITLE
defs.mk: Add standard build variable CPPFLAGS

### DIFF
--- a/defs.mk
+++ b/defs.mk
@@ -35,7 +35,7 @@ objs?=$(srcs:.c=.o)
 all:
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 %.so:
 	$(CC) -shared $(LDFLAGS) -o $@ $^ $(LIBS)


### PR DESCRIPTION
CPPFLAGS is used to pass C pre-processor flags (defines and includes).
It is used by e.g. the Debian package build system to pass such flags.

Signed-off-by: Tzafrir Cohen <mellanox@cohens.org.il>