### PR TITLE
ibsim: mcast_storm: remove umad_close_port call

### DIFF
--- a/tests/mcast_storm.c
+++ b/tests/mcast_storm.c
@@ -512,8 +512,6 @@ static int run_test(const struct test *t, struct test_data *td,
 	ret = t->func(&addr, td);
 
 	umad_unregister(addr.port, addr.agent);
-	umad_close_port(addr.port);
-	umad_done();
 
 	info("\'%s\' %s.\n", t->name, ret ? "failed" : "is done");
 


### PR DESCRIPTION
run_test function  is calling umad_close_port after every test.
In fact umad_close_port should be called once
from mad_rpc_close_port at the end of all tests.
The patch is fixing this issue.

Signed-off-by: root <vladimirk@mellanox.com>