### PR TITLE
Multiple umad file descriptors

### DIFF
--- a/defs.mk
+++ b/defs.mk
@@ -23,7 +23,7 @@ ifdef IB_DEV_DIR
   $(foreach l, mad umad, $(IB_DEV_DIR)/libib$(l)/.libs/libib$(l).so)
 else
  INCS:= -I$(dir $(libpath))include
- LIBS:= -L$(libpath) -libmad -libumad
+ LIBS:= -L$(libpath) -libmad -libumad -lpthread
 endif
 
 CFLAGS += -Wall -g -fpic -I. -I../include $(INCS)

--- a/umad2sim/umad2sim.c
+++ b/umad2sim/umad2sim.c
@@ -152,6 +152,8 @@ static unsigned umad2sim_initialized;
 static struct umad2sim_dev *devices[32];
 
 static pthread_mutex_t global_devices_mutex;
+static ssize_t umad2sim_read(struct umad2sim_dev *dev, void *buf, size_t count,
+			     unsigned int *mgmt_class);
 
 static ssize_t fd_data_mqueue_size(struct fd_data_t *fd_data);
 
@@ -469,6 +471,51 @@ static int close_fd(unsigned int fd)
 	return 0;
 }
 
+static void *__receiver(void *arg)
+{
+	struct umad2sim_dev *dev = (struct umad2sim_dev *) arg;
+	struct pollfd pfds;
+	struct umad_buf_t *buf;
+	unsigned int mgmt_class;
+	unsigned int fd;
+	struct fd_data_t *fd_data;
+
+	pfds.fd = dev->sim_client.fd_pktin;
+	pfds.events = POLLIN;
+	pfds.revents = 0;
+
+
+	while (1) {
+		if (real_poll(&pfds, 1, -1) < 0) {
+			ERROR("real_poll failure\n");
+			continue;
+		}
+		/* Do real read and post the message to the queue */
+		buf = alloc_umad_buf(sizeof(struct sim_request));
+
+		if (!buf)
+			continue;
+
+		buf->size = umad2sim_read(dev, buf->umad, buf->size, &mgmt_class);
+		pthread_mutex_lock(&global_devices_mutex);
+		fd = dev->agent_fds[mgmt_class];
+		fd_data = get_fd_data(dev, fd);
+
+		/* find appropriate mqueue and push to it */
+		if ((fd_data == NULL) || fd_data_enqueue(fd_data, buf) < 0) {
+			ERROR("Empty fd_data or fd_data_enqueue failed for FD %d\n",
+			      fd);
+			free_umad_buf(buf);
+		} else {
+			/* signal reader */
+			fd_event_signal(&fd_data->fd_event);
+		}
+		pthread_mutex_unlock(&global_devices_mutex);
+
+	}
+	return NULL;
+}
+
 /*
  *  sysfs stuff
  *
@@ -752,11 +799,11 @@ static int dev_sysfs_create(struct umad2sim_dev *dev)
  *
  */
 
-static ssize_t umad2sim_read(struct umad2sim_dev *dev, void *buf, size_t count)
+static ssize_t umad2sim_read(struct umad2sim_dev *dev, void *buf, size_t count,
+			     unsigned int *mgmt_class)
 {
 	struct sim_request req;
 	ib_user_mad_t *umad = (ib_user_mad_t *) buf;
-	unsigned mgmt_class;
 	int cnt;
 
 	DEBUG("umad2sim_read: %zu...\n", count);
@@ -766,29 +813,30 @@ static ssize_t umad2sim_read(struct umad2sim_dev *dev, void *buf, size_t count)
 	if (cnt < sizeof(req)) {
 		ERROR("umad2sim_read: partial request - skip.\n");
 		umad->status = EAGAIN;
+		*mgmt_class = 0;
 		return umad_size();
 	}
 
-	mgmt_class = mad_get_field(req.mad, 0, IB_MAD_MGMTCLASS_F);
+	*mgmt_class = mad_get_field(req.mad, 0, IB_MAD_MGMTCLASS_F);
 
 	DEBUG("umad2sim_read: mad: method=%x, response=%x, mgmtclass=%x, "
 	      "attrid=%x, attrmod=%x\n",
 	      mad_get_field(req.mad, 0, IB_MAD_METHOD_F),
 	      mad_get_field(req.mad, 0, IB_MAD_RESPONSE_F),
-	      mgmt_class,
+	      *mgmt_class,
 	      mad_get_field(req.mad, 0, IB_MAD_ATTRID_F),
 	      mad_get_field(req.mad, 0, IB_MAD_ATTRMOD_F));
 
-	if (mgmt_class >= arrsize(dev->agent_idx)) {
-		ERROR("bad mgmt_class 0x%x\n", mgmt_class);
-		mgmt_class = 0;
+	if (*mgmt_class >= arrsize(dev->agent_idx)) {
+		ERROR("bad mgmt_class 0x%x\n", *mgmt_class);
+		*mgmt_class = 0;
 	}
 
 	if (mad_get_field(req.mad, 0, IB_MAD_RESPONSE_F)) {
 		uint64_t trid = mad_get_field64(req.mad, 0, IB_MAD_TRID_F);
 		umad->agent_id = (trid >> 32) & 0xffff;
 	} else
-		umad->agent_id = dev->agent_idx[mgmt_class];
+		umad->agent_id = dev->agent_idx[*mgmt_class];
 
 	umad->status = ntohl(req.status);
 	umad->timeout_ms = 0;
@@ -876,49 +924,72 @@ static ssize_t umad2sim_write(struct umad2sim_dev *dev,
 	return count;
 }
 
-static int register_agent(struct umad2sim_dev *dev,
+static int register_agent(unsigned int fd,
 			  struct ib_user_mad_reg_req *req)
 {
-	int i;
-	DEBUG("register_agent: id = %u, qpn = %u, mgmt_class = %u,"
+	unsigned int i;
+	struct umad2sim_dev *dev;
+
+	pthread_mutex_lock(&global_devices_mutex);
+	dev = fd_to_dev(fd);
+
+	if (!dev) {
+		pthread_mutex_unlock(&global_devices_mutex);
+		return -1;
+	}
+	DEBUG("%s: fd = %u, qpn = %u, mgmt_class = %u,"
 	      " mgmt_class_version = %u, rmpp_version = %u\n",
-	      req->id, req->qpn, req->mgmt_class, req->mgmt_class_version,
+	      __func__,
+	      fd, req->qpn, req->mgmt_class, req->mgmt_class_version,
 	      req->rmpp_version);
 	for (i = 0; i < arrsize(dev->agents); i++)
 		if (dev->agents[i].id == (uint32_t)(-1)) {
 			req->id = i;
 			dev->agents[i] = *req;
 			dev->agent_idx[req->mgmt_class] = i;
+			dev->agent_fds[req->mgmt_class] = fd;
 			DEBUG("agent registered: %d\n", i);
+			pthread_mutex_unlock(&global_devices_mutex);
 			return 0;
 		}
+	pthread_mutex_unlock(&global_devices_mutex);
 	errno = ENOMEM;
 	return -1;
 }
 
-static int unregister_agent(struct umad2sim_dev *dev, unsigned int id)
+static int unregister_agent(unsigned int fd, unsigned int id)
 {
-	unsigned mgmt_class;
+	unsigned int mgmt_class;
+	struct umad2sim_dev *dev;
 
+	pthread_mutex_lock(&global_devices_mutex);
+	dev = fd_to_dev(fd);
+	if (!dev) {
+		pthread_mutex_unlock(&global_devices_mutex);
+		return -1;
+	}
 	if (id >= arrsize(dev->agents)) {
+		pthread_mutex_unlock(&global_devices_mutex);
 		errno = EINVAL;
 		return -1;
 	}
 	mgmt_class = dev->agents[id].mgmt_class;
 	dev->agents[id].id = (uint32_t)(-1);
 	dev->agent_idx[mgmt_class] = -1;
+	dev->agent_fds[mgmt_class] = -1;
+	pthread_mutex_unlock(&global_devices_mutex);
 	return 0;
 }
 
-static int umad2sim_ioctl(struct umad2sim_dev *dev, unsigned long request,
+static int umad2sim_ioctl(unsigned int fd, unsigned long request,
 			  void *arg)
 {
 	DEBUG("umad2sim_ioctl: %lu, %p...\n", request, arg);
 	switch (request) {
 	case IB_USER_MAD_REGISTER_AGENT:
-		return register_agent(dev, arg);
+		return register_agent(fd, arg);
 	case IB_USER_MAD_UNREGISTER_AGENT:
-		return unregister_agent(dev, *((unsigned int *)arg));
+		return unregister_agent(fd, *((unsigned int *)arg));
 	case IB_USER_MAD_ENABLE_PKEY:
 		return 0;
 	default:
@@ -927,7 +998,7 @@ static int umad2sim_ioctl(struct umad2sim_dev *dev, unsigned long request,
 	return -1;
 }
 
-static struct umad2sim_dev *umad2sim_dev_create(unsigned num, const char *name)
+static struct umad2sim_dev *umad2sim_dev_create(unsigned int num, const char *name)
 {
 	struct umad2sim_dev *dev;
 	int i;
@@ -945,12 +1016,22 @@ static struct umad2sim_dev *umad2sim_dev_create(unsigned num, const char *name)
 	if (sim_client_init(&dev->sim_client) < 0)
 		goto _error;
 
+	if (pthread_create(&dev->thread_id, NULL,
+			   __receiver, dev) < 0) {
+		sim_client_exit(&dev->sim_client);
+		goto _error;
+	}
+
 	dev->port = mad_get_field(&dev->sim_client.portinfo, 0,
 				  IB_PORT_LOCAL_PORT_F);
 	for (i = 0; i < arrsize(dev->agents); i++)
 		dev->agents[i].id = (uint32_t)(-1);
-	for (i = 0; i < arrsize(dev->agent_idx); i++)
+	for (i = 0; i < arrsize(dev->agent_idx); i++) {
 		dev->agent_idx[i] = (unsigned int)(-1);
+		dev->agent_fds[i] = (unsigned int)(-1);
+	}
+	for (i = 0; i < FD_PER_DEVICE; i++)
+		dev->fds[i] = NULL;
 
 	dev_sysfs_create(dev);
 
@@ -968,7 +1049,17 @@ static struct umad2sim_dev *umad2sim_dev_create(unsigned num, const char *name)
 
 static void umad2sim_dev_delete(struct umad2sim_dev *dev)
 {
+	int i;
+
 	sim_client_exit(&dev->sim_client);
+	pthread_cancel(dev->thread_id);
+	pthread_join(dev->thread_id, NULL);
+	for (i = 0; i < FD_PER_DEVICE; i++) {
+		if (dev->fds[i] != NULL) {
+			fd_data_release(dev->fds[i]);
+			dev->fds[i] = NULL;
+		}
+	}
 	free(dev);
 }
 
@@ -1012,13 +1103,16 @@ static void umad2sim_cleanup(void)
 	int i;
 
 	DEBUG("umad2sim_cleanup...\n");
+	pthread_mutex_lock(&global_devices_mutex);
 	for (i = 0; i < arrsize(devices); i++)
 		if (devices[i]) {
 			umad2sim_dev_delete(devices[i]);
 			devices[i] = NULL;
 		}
+	pthread_mutex_unlock(&global_devices_mutex);
 	strncpy(path, umad2sim_sysfs_prefix, sizeof(path) - 1);
 	unlink_dir(path, sizeof(path));
+	pthread_mutex_destroy(&global_devices_mutex);
 }
 
 static void umad2sim_init(void)
@@ -1033,6 +1127,7 @@ static void umad2sim_init(void)
 		ERROR("cannot init umad2sim. Exit.\n");
 		exit(-1);
 	}
+	pthread_mutex_init(&global_devices_mutex, NULL);
 	atexit(umad2sim_cleanup);
 	umad2sim_initialized = 1;
 }
@@ -1133,59 +1228,101 @@ int open(const char *path, int flags, ...)
 		return real_open(new_path, flags, mode);
 	}
 
+	pthread_mutex_lock(&global_devices_mutex);
 	for (i = 0; i < arrsize(devices); i++) {
 		if (!(dev = devices[i]))
 			continue;
 		if (!strncmp(path, dev->umad_path, sizeof(dev->umad_path))) {
-			return 1024 + i;
+			int fd_index;
+
+			fd_index = get_new_fd(dev);
+			pthread_mutex_unlock(&global_devices_mutex);
+			return (fd_index < 0) ? -1
+					      :  1024 + i * FD_PER_DEVICE +
+						 fd_index;
 		}
 		if (!strncmp(path, dev->issm_path, sizeof(dev->issm_path))) {
 			sim_client_set_sm(&dev->sim_client, 1);
+			pthread_mutex_unlock(&global_devices_mutex);
 			return 2048 + i;
 		}
 	}
-
+	pthread_mutex_unlock(&global_devices_mutex);
 	return real_open(path, flags, mode);
 }
 
 int close(int fd)
 {
-	struct umad2sim_dev *dev;
-
 	DEBUG("libs_wrap: close %d...\n", fd);
 	CHECK_INIT();
 
-	if (fd >= 2048) {
-		dev = devices[fd - 2048];
-		sim_client_set_sm(&dev->sim_client, 0);
-		return 0;
-	} else if (fd >= 1024) {
-		return 0;
-	} else
-		return real_close(fd);
+	if (fd >= 1024)
+		return close_fd(fd);
+
+	return real_close(fd);
 }
 
 ssize_t read(int fd, void *buf, size_t count)
 {
+	struct umad2sim_dev *dev;
+	struct fd_data_t *fd_data;
+	struct umad_buf_t *umad_buf;
+	int ret;
+
 	CHECK_INIT();
 
 	if (fd >= 2048)
 		return -1;
-	else if (fd >= 1024)
-		return umad2sim_read(devices[fd - 1024], buf, count);
-	else
+	else if (fd >= 1024) {
+
+		pthread_mutex_lock(&global_devices_mutex);
+		dev = fd_to_dev(fd);
+		fd_data = get_fd_data(dev, fd);
+		if (!fd_data) {
+			pthread_mutex_unlock(&global_devices_mutex);
+			return -1;
+		}
+		umad_buf = fd_data_dequeue(fd_data);
+		pthread_mutex_unlock(&global_devices_mutex);
+		if (!umad_buf) {
+			DEBUG("No data in queue\n");
+			return -EWOULDBLOCK;
+		}
+		if (umad_buf->size > count) {
+			ERROR("received data size %u larger than requested buf size %u\n",
+			     (unsigned int) umad_buf->size, (unsigned int) count);
+			umad_buf->size = count;
+		}
+
+		memcpy(buf, umad_buf->umad, umad_buf->size);
+
+		ret = umad_buf->size;
+		free_umad_buf(umad_buf);
+
+		return ret;
+	} else
 		return real_read(fd, buf, count);
 }
 
 ssize_t write(int fd, const void *buf, size_t count)
 {
+	struct umad2sim_dev *dev;
+	ssize_t res;
+
 	CHECK_INIT();
 
 	if (fd >= 2048)
 		return -1;
-	else if (fd >= 1024)
-		return umad2sim_write(devices[fd - 1024], buf, count);
-	else
+	else if (fd >= 1024) {
+		pthread_mutex_lock(&global_devices_mutex);
+		dev = fd_to_dev(fd);
+		if (!dev)
+			res = -1;
+		else
+			res = umad2sim_write(dev, buf, count);
+		pthread_mutex_unlock(&global_devices_mutex);
+		return res;
+	} else
 		return real_write(fd, buf, count);
 }
 
@@ -1202,33 +1339,45 @@ int ioctl(int fd, unsigned long request, ...)
 	if (fd >= 2048)
 		return -1;
 	else if (fd >= 1024)
-		return umad2sim_ioctl(devices[fd - 1024], request, arg);
+		return umad2sim_ioctl(fd, request, arg);
 	else
 		return real_ioctl(fd, request, arg);
 }
 
 int poll(struct pollfd *pfds, nfds_t nfds, int timeout)
 {
-	int saved_fds[nfds];
-	int i;
+	struct umad2sim_dev *dev = NULL;
+	struct fd_data_t *fd_data = NULL;
+	unsigned int i, index;
 	int ret;
 
 	CHECK_INIT();
-
+	pthread_mutex_lock(&global_devices_mutex);
 	for (i = 0; i < nfds; i++) {
 		if (pfds[i].fd >= 1024 && pfds[i].fd < 2048) {
-			struct umad2sim_dev *dev = devices[pfds[i].fd - 1024];
-			saved_fds[i] = pfds[i].fd;
-			pfds[i].fd = dev->sim_client.fd_pktin;
-		} else
-			saved_fds[i] = 0;
+			dev = fd_to_dev(pfds[i].fd);
+			fd_data = get_fd_data(dev, pfds[i].fd);
+			index = i;
+			break;
+		}
 	}
+	pthread_mutex_unlock(&global_devices_mutex);
+	if (fd_data != NULL) {
+		/* timeout in microsec*/
+		ret = fd_event_wait_on(fd_data,
+				       (timeout < 0) ? EVENT_NO_TIMEOUT :
+				       timeout * 1000);
+		pfds[index].revents = 0;
+		if (ret == 0) {
+			pfds[index].revents = POLLIN;
+			ret = 1;
+		} else if (ret == FD_TIMEOUT)
+			ret = 0;
+		else
+			ret = -1;
 
-	ret = real_poll(pfds, nfds, timeout);
-
-	for (i = 0; i < nfds; i++)
-		if (saved_fds[i])
-			pfds[i].fd = saved_fds[i];
-
+	} else {
+		ret = real_poll(pfds, nfds, timeout);
+	}
 	return ret;
 }

--- a/umad2sim/umad2sim.c
+++ b/umad2sim/umad2sim.c
@@ -40,6 +40,8 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/time.h>
+#include <sys/errno.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -48,7 +50,7 @@
 #include <string.h>
 #include <dirent.h>
 #include <dlfcn.h>
-
+#include <pthread.h>
 #include <infiniband/umad.h>
 #include <infiniband/mad.h>
 
@@ -64,6 +66,8 @@
 
 #define arrsize(a) (sizeof(a)/sizeof(a[0]))
 
+#define EVENT_NO_TIMEOUT	0xFFFFFFFF
+#define FD_TIMEOUT	12
 
 #define IB_PORT_EXT_SPEED_SUPPORTED_MASK (1<<14)
 
@@ -83,6 +87,17 @@ struct msg_queue_t {
 	ssize_t queue_size;
 };
 
+struct fd_event_t {
+	pthread_cond_t condvar;
+	pthread_mutex_t mutex;
+};
+
+struct fd_data_t {
+	struct fd_event_t fd_event;
+	struct msg_queue_t *mqueue;
+} fd_data_t;
+
+
 struct ib_user_mad_reg_req {
 	uint32_t id;
 	uint32_t method_mask[4];
@@ -93,16 +108,20 @@ struct ib_user_mad_reg_req {
 	uint8_t rmpp_version;
 };
 
+#define FD_PER_DEVICE 8
+
 struct umad2sim_dev {
-	int fd;
+	pthread_t thread_id;
 	unsigned num;
 	char name[32];
 	uint8_t port;
 	struct sim_client sim_client;
-	unsigned agent_idx[256];
+	unsigned int agent_idx[256];
+	unsigned int agent_fds[256];
 	struct ib_user_mad_reg_req agents[32];
 	char umad_path[256];
 	char issm_path[256];
+	struct fd_data_t *fds[FD_PER_DEVICE];
 };
 
 static int (*real_open) (const char *path, int flags, ...);
@@ -131,6 +150,88 @@ static char umad2sim_sysfs_prefix[32];
 
 static unsigned umad2sim_initialized;
 static struct umad2sim_dev *devices[32];
+
+static pthread_mutex_t global_devices_mutex;
+
+static ssize_t fd_data_mqueue_size(struct fd_data_t *fd_data);
+
+static int fd_event_init(struct fd_event_t * const p_event)
+{
+	if (pthread_cond_init(&p_event->condvar, NULL))
+		return -1;
+	if (pthread_mutex_init(&p_event->mutex, NULL)) {
+		pthread_cond_destroy(&p_event->condvar);
+		return -1;
+	}
+	return 0;
+}
+
+static void fd_event_destroy(struct fd_event_t * const p_event)
+{
+	pthread_cond_broadcast(&p_event->condvar);
+	pthread_cond_destroy(&p_event->condvar);
+	pthread_mutex_destroy(&p_event->mutex);
+}
+
+static void fd_event_signal(struct fd_event_t * const p_event)
+{
+
+	pthread_mutex_lock(&p_event->mutex);
+	pthread_cond_signal(&p_event->condvar);
+	pthread_mutex_unlock(&p_event->mutex);
+}
+
+static int fd_event_wait_on(struct fd_data_t * const fd_data,
+			    const uint32_t wait_us)
+{
+	int status = -1;
+	int wait_ret;
+	struct timespec timeout;
+	struct timeval curtime;
+	struct fd_event_t *p_event = &fd_data->fd_event;
+	ssize_t size;
+
+	pthread_mutex_lock(&p_event->mutex);
+	size = fd_data_mqueue_size(fd_data);
+
+	if (size) {
+		pthread_mutex_unlock(&p_event->mutex);
+		return 0;
+	}
+
+	if (wait_us == 0) {
+		pthread_mutex_unlock(&p_event->mutex);
+		return FD_TIMEOUT;
+	}
+	
+	if (wait_us == EVENT_NO_TIMEOUT) {
+		/* Wait for condition variable to be signaled */
+		if (!pthread_cond_wait(&p_event->condvar, &p_event->mutex))
+			status = 0;
+		pthread_mutex_unlock(&p_event->mutex);
+		return status;
+	}
+
+	if (gettimeofday(&curtime, NULL) == 0) {
+		unsigned long long n_sec =
+			curtime.tv_usec*1000 + ((wait_us % 1000000)) * 1000;
+			timeout.tv_sec = curtime.tv_sec + (wait_us / 1000000)
+			    + (n_sec / 1000000000);
+			timeout.tv_nsec = n_sec % 1000000000;
+
+			wait_ret = pthread_cond_timedwait(&p_event->condvar,
+							  &p_event->mutex,
+							  &timeout);
+			if (wait_ret == 0) {
+				size = fd_data_mqueue_size(fd_data);
+				status = size ? 0 : -1;
+			} else if (wait_ret == ETIMEDOUT)
+				status = FD_TIMEOUT;
+
+			pthread_mutex_unlock(&p_event->mutex);
+	}
+	return status;
+}
 
 static struct umad_buf_t *alloc_umad_buf(ssize_t size)
 {
@@ -224,6 +325,148 @@ static struct list_elem_t *mqueue_remove_head(struct msg_queue_t *mqueue)
 static void mqueue_destroy(struct msg_queue_t *mqueue)
 {
 	free(mqueue);
+}
+
+static struct fd_data_t *fd_data_create(void)
+{
+	struct fd_data_t *ptr;
+
+	ptr = (struct fd_data_t *) malloc(sizeof(struct fd_data_t));
+	if (!ptr)
+		return NULL;
+
+	ptr->mqueue = mqueue_create();
+	if (!ptr->mqueue) {
+		free(ptr);
+		return NULL;
+	}
+
+	if (fd_event_init(&ptr->fd_event)) {
+		mqueue_destroy(ptr->mqueue);
+		free(ptr);
+		return NULL;
+	}
+
+	return ptr;
+}
+
+/* should be called under fd_data->event->mutex */
+static struct umad_buf_t *fd_data_dequeue(struct fd_data_t *fd_data)
+{
+	struct list_elem_t *ptr;
+	struct umad_buf_t *data_ptr = NULL;
+
+	ptr = mqueue_remove_head(fd_data->mqueue);
+	if (ptr) {
+		data_ptr = ptr->data;
+		free(ptr);
+	}
+	return data_ptr;
+}
+/* should be called under global lock */
+static void fd_data_release(struct fd_data_t *fd_data)
+{
+	struct umad_buf_t *ptr;
+
+	while ((ptr = fd_data_dequeue(fd_data)) != NULL)
+		free_umad_buf(ptr);
+
+	mqueue_destroy(fd_data->mqueue);
+	fd_event_destroy(&fd_data->fd_event);
+	free(fd_data);
+}
+
+/* should be called under fd_data->event->mutex */
+static int fd_data_enqueue(struct fd_data_t *fd_data, void *data)
+{
+	struct list_elem_t *ptr;
+	int result = 0;
+
+	ptr = mqueue_add_tail(fd_data->mqueue, data);
+	if (!ptr)
+		result = -1;
+	return result;
+}
+
+/* should be called under global lock */
+static struct fd_data_t *get_fd_data(struct umad2sim_dev *dev, unsigned int fd)
+{
+	if (fd < 1024 && fd >= 2048)
+		return NULL;
+
+	if (!dev)
+		return NULL;
+
+	return dev->fds[(fd - 1024) % FD_PER_DEVICE];
+}
+
+/* should be called under fd_data->event->mutex */
+static ssize_t fd_data_mqueue_size(struct fd_data_t *fd_data)
+{
+	return mqueue_get_size(fd_data->mqueue);
+}
+
+/* Returns index into dev->fds where new fd_data_t pointer was stored */
+static int get_new_fd(struct umad2sim_dev *dev)
+{
+	int i;
+
+	for (i = 0; i < FD_PER_DEVICE; i++) {
+		if (dev->fds[i] != NULL)
+			continue;
+		dev->fds[i] = fd_data_create();
+		return (dev->fds[i] == NULL) ? -1 : i;
+	}
+	/* all FDs allocated */
+	return -1;
+}
+
+static struct umad2sim_dev *fd_to_dev(unsigned int fd)
+{
+	if (fd >= 2048)
+		return devices[fd - 2048];
+	if (fd >= 1024)
+		return devices[(fd - 1024) / FD_PER_DEVICE];
+
+	return NULL;
+}
+
+static int close_fd(unsigned int fd)
+{
+	struct umad2sim_dev *dev;
+	int i, idx;
+	struct fd_data_t *fd_data;
+
+	if (fd < 1024)
+		return 0;
+	pthread_mutex_lock(&global_devices_mutex);
+	dev = fd_to_dev(fd);
+	if (!dev) {
+		pthread_mutex_unlock(&global_devices_mutex);
+		return 0;
+	}
+	if (fd >= 2048) {
+		sim_client_set_sm(&dev->sim_client, 0);
+		pthread_mutex_unlock(&global_devices_mutex);
+		return 0;
+	}
+
+	fd_data = get_fd_data(dev, fd);
+	if (fd_data)
+		fd_data_release(fd_data);
+
+	for (i = 0; i < 256; i++) {
+		if (dev->agent_fds[i] == fd) {
+			dev->agent_fds[i] = -1;
+			idx = dev->agent_idx[i];
+			dev->agents[idx].id = (uint32_t)(-1);
+			dev->agent_idx[i] = -1;
+			break;
+		}
+	}
+	dev->fds[(fd - 1024) % FD_PER_DEVICE] = NULL;
+	pthread_mutex_unlock(&global_devices_mutex);
+	return 0;
 }
 
 /*
@@ -636,7 +879,7 @@ static ssize_t umad2sim_write(struct umad2sim_dev *dev,
 static int register_agent(struct umad2sim_dev *dev,
 			  struct ib_user_mad_reg_req *req)
 {
-	unsigned i;
+	int i;
 	DEBUG("register_agent: id = %u, qpn = %u, mgmt_class = %u,"
 	      " mgmt_class_version = %u, rmpp_version = %u\n",
 	      req->id, req->qpn, req->mgmt_class, req->mgmt_class_version,
@@ -653,9 +896,10 @@ static int register_agent(struct umad2sim_dev *dev,
 	return -1;
 }
 
-static int unregister_agent(struct umad2sim_dev *dev, unsigned id)
+static int unregister_agent(struct umad2sim_dev *dev, unsigned int id)
 {
 	unsigned mgmt_class;
+
 	if (id >= arrsize(dev->agents)) {
 		errno = EINVAL;
 		return -1;
@@ -674,7 +918,7 @@ static int umad2sim_ioctl(struct umad2sim_dev *dev, unsigned long request,
 	case IB_USER_MAD_REGISTER_AGENT:
 		return register_agent(dev, arg);
 	case IB_USER_MAD_UNREGISTER_AGENT:
-		return unregister_agent(dev, *((unsigned *)arg));
+		return unregister_agent(dev, *((unsigned int *)arg));
 	case IB_USER_MAD_ENABLE_PKEY:
 		return 0;
 	default:
@@ -686,7 +930,7 @@ static int umad2sim_ioctl(struct umad2sim_dev *dev, unsigned long request,
 static struct umad2sim_dev *umad2sim_dev_create(unsigned num, const char *name)
 {
 	struct umad2sim_dev *dev;
-	unsigned i;
+	int i;
 
 	DEBUG("umad2sim_dev_create: %s...\n", name);
 
@@ -706,7 +950,7 @@ static struct umad2sim_dev *umad2sim_dev_create(unsigned num, const char *name)
 	for (i = 0; i < arrsize(dev->agents); i++)
 		dev->agents[i].id = (uint32_t)(-1);
 	for (i = 0; i < arrsize(dev->agent_idx); i++)
-		dev->agent_idx[i] = (unsigned)(-1);
+		dev->agent_idx[i] = (unsigned int)(-1);
 
 	dev_sysfs_create(dev);
 
@@ -765,7 +1009,8 @@ static void unlink_dir(char path[], unsigned size)
 static void umad2sim_cleanup(void)
 {
 	char path[1024];
-	unsigned i;
+	int i;
+
 	DEBUG("umad2sim_cleanup...\n");
 	for (i = 0; i < arrsize(devices); i++)
 		if (devices[i]) {
@@ -865,7 +1110,7 @@ int open(const char *path, int flags, ...)
 	struct umad2sim_dev *dev;
 	va_list args;
 	mode_t mode = 0;
-	unsigned i;
+	int i;
 
 	CHECK_INIT();
 
@@ -965,7 +1210,7 @@ int ioctl(int fd, unsigned long request, ...)
 int poll(struct pollfd *pfds, nfds_t nfds, int timeout)
 {
 	int saved_fds[nfds];
-	unsigned i;
+	int i;
 	int ret;
 
 	CHECK_INIT();


### PR DESCRIPTION
This set of patches adds support of opening multiple umad descriptors in ibsim.
Opening multiple umad descriptors feature is used by Infiniband management applications to improve resiliency and accessibility. For instance SMP and SA can be managed via separate umad file descriptors.
In order to test such applications with ibsim, ibsim should support this feature.
