### PR TITLE
umad2sim: call umad2sim_init in opendir

### DIFF
--- a/umad2sim/umad2sim.c
+++ b/umad2sim/umad2sim.c
@@ -1156,6 +1156,12 @@ DIR *opendir(const char *path)
 	char new_path[1024];
 
 	CHECK_INIT();
+
+	if (!umad2sim_initialized && (is_sysfs_file(path) ||
+				      !strncmp(path, umad_dev_dir,
+					       strlen(umad_dev_dir))))
+		umad2sim_init();
+
 	DEBUG("libs_wrap: opendir: %s...\n", path);
 
 	if (is_sysfs_file(path)) {


### PR DESCRIPTION
When using ibsim, ibstat doesn't return any output with latest libibumad.
This happens due to recent change in umad_get_ca_device_list,
which is now using opendir system call instead of scandir.
As umad_get_ca_device_list is called by ibstat
code before open or scandir system calls,
umad2sim remains unitialized.

The patch fixes the issue by adding umad2sim_init call
in opendir wrapper.

Signed-off-by: Vladimir Koushnir <vladimirk@nvidia.com>