### PR TITLE
ibsim.c: Fix compilation warning

### DIFF
--- a/ibsim/ibsim.c
+++ b/ibsim/ibsim.c
@@ -338,7 +338,9 @@ static void set_issm(Port *port, unsigned issm)
 
 static int sim_ctl_set_issm(Client * cl, struct sim_ctl * ctl)
 {
-	int issm = *(int *)ctl->data;
+	int issm;
+
+	memcpy(&issm, &ctl->data[0], sizeof(int));
 
 	VERB("set issm %d port %" PRIx64, issm, cl->port->portguid);
 	cl->issm = issm;


### PR DESCRIPTION
The patch fixes compulation warning:

ibsim.c: In function sim_ctl_set_issm:
ibsim.c:361:2: warning: dereferencing type-punned pointer will break
strict-aliasing rules [-Wstrict-aliasing]
  int issm = *(int *)ctl->data;

Signed-off-by: Vladimir Koushnir <vladimirk@nvidia.com>