### PR TITLE
Distcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,18 @@ install:
 
 dist:
 	./dist.sh RELEASE=$(RELEASE)
+
+distcheck: dist
+	@set -e; set -x; \
+	tarball=`ls *.tar.gz | head -n 1`; \
+	rm -rf checkdir; \
+	mkdir checkdir; \
+	cd checkdir; \
+	tar xzf ../$$tarball; \
+	cd *; \
+	make; \
+	make install DESTDIR=`pwd`/root; \
+	cd .. ;\
+	rm -rf checkdir
+
+.PHONEY: all clean dep dist distcheck install

--- a/dist.sh
+++ b/dist.sh
@@ -7,6 +7,17 @@ tarball=${distdir}.tar.gz
 
 test -z "$RELEASE" || rel=$RELEASE
 
+dch_entry() {
+	cat <<EOF
+ibsim ($ver) unstable; urgency=low
+
+  * New upstream release.
+
+ --  Tzafrir Cohen <nvidia@cohens.org.il>  `date -R`
+
+EOF
+}
+
 rm -f $tarball
 rm -rf $distdir
 mkdir $distdir
@@ -18,6 +29,8 @@ cp -a --parents $files debian \
 cat ibsim.spec.in \
 		| sed -e 's/@VERSION@/'$ver'/' -e 's/@RELEASE@/'$rel'/' -e 's/@TARBALL@/'$tarball'/' \
 		> $distdir/ibsim.spec
+
+(dch_entry; cat debian/changelog) >$distdir/debian/changelog
 
 tar czf $tarball $distdir
 rm -rf $distdir

--- a/dist.sh
+++ b/dist.sh
@@ -11,7 +11,7 @@ rm -f $tarball
 rm -rf $distdir
 mkdir $distdir
 
-files=`find . -name '*.[ch]' -o -name Makefile`
+files=`find . -name '*.[ch]' -o -name Makefile -o -name '*.in'`
 cp -a --parents $files debian \
 	defs.mk README COPYING TODO net-examples scripts tests $distdir
 


### PR DESCRIPTION
Fix a build issue due to ibsim-run.in missing from the dist tarball, and add a simple way to test it.